### PR TITLE
Refactor buffered middleware

### DIFF
--- a/buffered.go
+++ b/buffered.go
@@ -1,57 +1,36 @@
 package m3
 
-import "io"
-
-// ---
-// ### **NewBufferedWriter**
+import (
+    "bufio"
+    "io"
+)
 
 // NewBufferedWriter creates a buffered writer with the given buffer
-// size. A `WriterMiddleware` is returned which wraps the log's
-// internal `io.WriteCloser` in a `bufio.Writer`.
-func NewBufferedWriterMiddleware(size int) WriterMiddleware {
-    return func(writer io.WriteCloser) io.WriteCloser {
-        return bufferedWriteCloser{size, 0, make([]byte, 0, size), writer}
+// size. A `WriterMiddleware` is returned which wraps the given
+// `io.WriteCloser` in a `bufio.Writer`. On Close the buffer is flushed and the Close method is forwarded.
+func NewBufferedWriter(size int) WriterMiddleware {
+    return func(writeCloser io.WriteCloser) io.WriteCloser {
+        return &bufferedWriter{bufio.NewWriterSize(writeCloser, size), writeCloser}
     }
 }
 
-// > The buffered middleware is implemented as a `bufferedWriteCloser`
-// which requires the newly created `bufio.Writer` as well as the
-// log's internal `io.WriteCloser`.
-type bufferedWriteCloser struct {
-    size   int
-    offset int
-    buffer []byte
-    parent io.WriteCloser
+type bufferedWriter struct {
+    writer *bufio.Writer
+    closer io.Closer
 }
 
-// #### Write
-
-// Write writes the data into the buffer.
-func (b bufferedWriteCloser) Write(data []byte) (n int, err error) {
-    if len(data) > b.size {
-        return b.parent.Write(data)
-    }
-
-    if len(data)+b.offset > b.size {
-        b.parent.Write(b.buffer[:b.offset])
-
-        n = b.offset
-        b.offset = 0
-        return
-    }
-
-    copy(b.buffer[:len(data)], data)
-    b.offset += len(data)
-    return len(data), nil
+func (c *bufferedWriter) Write(data []byte) (int, error) {
+    return c.writer.Write(data)
 }
 
-// #### Close
+func (c *bufferedWriter) Close() error {
+    c.writer.Flush()
+    return c.closer.Close()
+}
 
-// Close flushes the buffer and then closes the parent `io.WriteCloser.`
-func (b bufferedWriteCloser) Close() error {
-    if b.offset > 0 {
-        b.parent.Write(b.buffer[:b.offset])
-        b.offset = 0
+// NewBufferedReader creates a ReaderMiddleware based on bufio.Reader.
+func NewBufferedReader(size int) ReaderMiddleware {
+    return func(readCloser io.ReadCloser) io.ReadCloser {
+        return &ReadCombiner{bufio.NewReaderSize(readCloser, size), readCloser}
     }
-    return b.parent.Close()
 }

--- a/core.go
+++ b/core.go
@@ -74,3 +74,29 @@ func (w *writer) Use(writers ...WriterMiddleware) {
         w.wc = writer(w.wc)
     }
 }
+
+type WriteCombiner struct {
+    writer io.Writer
+    closer io.Closer
+}
+
+func (c *WriteCombiner) Write(data []byte) (int, error) {
+    return c.writer.Write(data)
+}
+
+func (c *WriteCombiner) Close() error {
+    return c.closer.Close()
+}
+
+type ReadCombiner struct {
+    reader io.Reader
+    closer io.Closer
+}
+
+func (c *ReadCombiner) Read(data []byte) (int, error) {
+    return c.reader.Read(data)
+}
+
+func (c *ReadCombiner) Close() error {
+    return c.closer.Close()
+}


### PR DESCRIPTION
Moving to stdlib bufio package makes the buffered middleware inherently better. So why not use it. Also two types were added to core: the WriteCombiner and the ReadCombiner. These new types allow for easier manipulation of io.Reader implementations.